### PR TITLE
[Dynamic] bj1904 01타일 / bj11060 점프점프

### DIFF
--- a/dynamic/bj11060.py
+++ b/dynamic/bj11060.py
@@ -1,0 +1,17 @@
+# 소요시간: 약 50분
+
+n = int(input())
+arr = [0] + list(map(int, input().split()))
+dp = [0, 0] + [float("inf")] * (n - 1) # n번째로 갈 수 있는 최소 점프 수 (1번째는 항상 0)
+
+for i in range(2, n + 1): # dp(n)을 찾기 위해 반복
+    for j in range(1, i + 1): # i: 도달해야 하는 곳 / j: 현재위치
+        if(arr[j] >= i - j): # 현재 갈 수 있는 거리(arr[j])가 i까지의 거리(i-j)보다 같거나 커야
+            minJump = dp[j] + 1
+            if(dp[i] > minJump):
+                dp[i] = minJump
+                
+if(dp[n] == float("inf")):
+    print(-1)
+else:
+    print(dp[n])

--- a/dynamic/bj1904.py
+++ b/dynamic/bj1904.py
@@ -1,0 +1,9 @@
+# 소요시간: 25분
+
+n = int(input())
+dp = [0, 1, 2] + [0] * (n - 1)
+
+for i in range(3, n + 1):
+    dp[i] = (dp[i-1] + dp[i-2]) % 15746
+    
+print(dp[n])


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 :
- bj1904 01타일
![image](https://user-images.githubusercontent.com/69359774/218354970-9e826414-fac1-4df2-ab42-62a3deed9817.png)

- bj11060 점프점프
![image](https://user-images.githubusercontent.com/69359774/218354989-2a21b2fb-85ae-4781-99aa-eea3bf802563.png)


## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 1904 문제 메모리 초과: 출력 조건 확인 미흡(나머지 계산 생략) / 런타임에러: 입력값이 1일때를 고려하지 않음(dp 배열 원소 2개 생성 후 3번째 인덱스에 접근함)

## ⏱️시간복잡도
bj1904 01타일: O(N)
bj11060 점프점프: O(NlogN)