### PR TITLE
[BFS/DFS] bj2606 바이러스 / bj11725 트리의 부모 찾기

### DIFF
--- a/bfs/bj11725.py
+++ b/bfs/bj11725.py
@@ -1,0 +1,25 @@
+# 소요시간: 70분
+
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+graph = [[] for _ in range(n + 1)]
+for _ in range(n - 1):
+    node1, node2 = map(int, input().split())
+    graph[node1].append(node2)
+    graph[node2].append(node1)
+    
+queue = deque([1])
+parent = [1, 1] + [0] * (n - 1) # 각 index번째 노드의 부모 리스트(0으로 초기화)
+
+while(len(queue) > 0):
+    pop = queue.popleft()
+    for i in range(len(graph[pop])): # graph[pop][i] => 6, 4
+        if(parent[graph[pop][i]] == 0): # 부모 없을 시
+            parent[graph[pop][i]] = pop # 갱신
+            queue.append(graph[pop][i])
+        
+for i in parent[2:]: # 2번째 노드부터 부모 노드 출력
+    print(i)

--- a/bfs/bj2606.py
+++ b/bfs/bj2606.py
@@ -1,0 +1,27 @@
+#소요시간: 40분
+
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+com_n = int(input())
+line = int(input())
+arr = [[0] for _ in range(com_n + 1)]
+
+for _ in range(line):
+    com1, com2 = map(int, input().split())
+    arr[com1].append(com2)
+    arr[com2].append(com1)
+
+res = -1 # 1 제외
+queue = deque([1])
+
+while(len(queue) != 0):
+    pop = queue.popleft()
+    if(arr[pop][0] == 0):
+        for i in range(1, len(arr[pop])):
+            queue.append(arr[pop][i])
+        res += 1
+        arr[pop][0] = 1
+
+print(res)

--- a/bfs_dfs/bj11724.py
+++ b/bfs_dfs/bj11724.py
@@ -1,0 +1,31 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+graph = [[] for _ in range(n)]
+
+q = deque([])
+visited = []
+res = 0
+
+def bfs(v):
+    q.append(v)
+    while(q):
+        node = q.popleft()
+        if(node not in visited):
+            q.extend(graph[node])
+            visited.append(node)
+    visited.append(v)
+
+for _ in range(m):
+    n1, n2 = map(int, input().split())
+    graph[n1-1].append(n2-1)
+    graph[n2-1].append(n1-1)
+    
+for i in range(n): # 모든 정점의 연결요소를 확인
+    if(i not in visited): # 방문했다면 연결 요소에 포함된 정점이므로 제외
+        bfs(i)
+        res += 1 # 연결 요소 개수 추가
+    
+print(res)

--- a/bfs_dfs/bj11724.py
+++ b/bfs_dfs/bj11724.py
@@ -1,3 +1,5 @@
+# 소요시간: 15분
+
 from collections import deque
 import sys
 input = sys.stdin.readline

--- a/bfs_dfs/bj1260.py
+++ b/bfs_dfs/bj1260.py
@@ -1,0 +1,35 @@
+from collections import deque
+
+visited_dfs = []
+visited_bfs = []
+
+def dfs(v):
+    visited_dfs.append(v)
+    for i in graph[v]:
+        if(i not in visited_dfs):
+            dfs(i)       
+    return visited_dfs
+
+def bfs(v):
+    q = deque([v])
+    while q:
+        node = q.popleft()
+        if(node not in visited_bfs):
+            visited_bfs.append(node)
+            q.extend(graph[node])
+    return visited_bfs
+
+
+n, m, v = map(int, input().split())
+graph = [[] for i in range(n + 1)]
+
+for _ in range(m):
+    num1, num2 = map(int, input().split())
+    graph[num1].append(num2)
+    graph[num2].append(num1)
+    
+for i in graph:
+    i.sort()
+    
+print(*dfs(v))
+print(*bfs(v))


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 :
- bj2606 바이러스
![image](https://user-images.githubusercontent.com/69359774/219936635-baf3b818-04dc-4875-9852-286ec6db5d9a.png)

- bj11725 트리의 부모 찾기
![image](https://user-images.githubusercontent.com/69359774/219936613-081ca347-cd20-437e-9745-bc3bd29de836.png)


## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 어떻게 풀었는지 기억나면 수정할게요.. 둘 다 BFS로 해결했습니다.
- 1260 DFS와 BFS는 DFS를 덜 해결해서 못추가했어요 금방 올릴게요😱

## ⏱️시간복잡도
bj2606 바이러스: O(V^2)
bj11725 트리의 부모 찾기: O(V^2)